### PR TITLE
Add frame generation mods detection + update for 2.2

### DIFF
--- a/FindAllErrors.bat
+++ b/FindAllErrors.bat
@@ -210,10 +210,20 @@ if not defined redscript_missing (
 set "framegen_section="
 set "framegen_found="
 
+:: Check for dlssg_to_fsr3_amd_is_better.dll
+if exist "%CYBERPUNKDIR%\bin\x64\dlssg_to_fsr3_amd_is_better.dll" (
+        set "framegen_section=DLSSG-to-FSR3 DLL file is present"
+        set "framegen_found=1"
+)
+
 :: Check for dlss-enabler.dll
 if exist "%CYBERPUNKDIR%\bin\x64\dlss-enabler.dll" (
     for /f "delims=" %%a in ('powershell -Command "$versionInfo = (Get-Item '%CYBERPUNKDIR%\bin\x64\dlss-enabler.dll').VersionInfo.ProductVersion; if ($versionInfo) { Write-Output $versionInfo }"') do (
-        set "framegen_section=FSR 3 FrameGen For Cyberpunk 2077 (DLSS Enabler 2077 Edition) (dlss-enabler.dll) Version: %%a"
+        if defined framegen_section (
+            set "framegen_section=!framegen_section!\nFSR 3 FrameGen For Cyberpunk 2077 (DLSS Enabler 2077 Edition) (dlss-enabler.dll) Version: %%a"
+        ) else (
+            set "framegen_section=FrameGen Ghosting `Fix` DLSS Enabler Bridge 2077 (dlss-enabler-bridge-2077.dll) Version: %%a"
+        )
         set "framegen_found=1"
     )
 )

--- a/FindAllErrors.bat
+++ b/FindAllErrors.bat
@@ -103,7 +103,7 @@ for /f "tokens=2 delims==" %%a in ('wmic datafile where name^="!exe_path:\=\\!" 
 )      
 
 :: update executable version here
-set LATESTVERSION=3.0.77.64623
+set LATESTVERSION=3.0.78.41888
 
 :: if not the current game version, yell at the user and deploy R.A.B.I.D.S.
 if not "!version!"=="%LATESTVERSION%" (

--- a/FindAllErrors.bat
+++ b/FindAllErrors.bat
@@ -107,7 +107,7 @@ set LATESTVERSION=3.0.78.41888
 
 :: if not the current game version, yell at the user and deploy R.A.B.I.D.S.
 if not "!version!"=="%LATESTVERSION%" (
-  echo Please update the game before proceeding. The most recent game version is 2.13 with the executable version %LATESTVERSION%
+  echo Please update the game before proceeding. The most recent game version is 2.2 with the executable version %LATESTVERSION%
   echo.
   echo Deploying Roving Autonomous Bartmoss Interface Drones....
   FOR /L %%S IN (10, -1, 1) DO (

--- a/FindAllErrors.bat
+++ b/FindAllErrors.bat
@@ -222,7 +222,7 @@ if exist "%CYBERPUNKDIR%\bin\x64\dlss-enabler.dll" (
         if defined framegen_section (
             set "framegen_section=!framegen_section!\nFSR 3 FrameGen For Cyberpunk 2077 (DLSS Enabler 2077 Edition) (dlss-enabler.dll) Version: %%a"
         ) else (
-            set "framegen_section=FrameGen Ghosting `Fix` DLSS Enabler Bridge 2077 (dlss-enabler-bridge-2077.dll) Version: %%a"
+            set "framegen_section=FSR 3 FrameGen For Cyberpunk 2077 (DLSS Enabler 2077 Edition) (dlss-enabler.dll) Version: %%a"
         )
         set "framegen_found=1"
     )

--- a/FindAllErrors.bat
+++ b/FindAllErrors.bat
@@ -206,6 +206,37 @@ if not defined redscript_missing (
     echo Redscript: installed correctly >> "%output_file%"
 )
 
+:: Initialize frame generation mods section
+set "framegen_section="
+set "framegen_found="
+
+:: Check for dlss-enabler.dll
+if exist "%CYBERPUNKDIR%\bin\x64\dlss-enabler.dll" (
+    for /f "delims=" %%a in ('powershell -Command "$versionInfo = (Get-Item '%CYBERPUNKDIR%\bin\x64\dlss-enabler.dll').VersionInfo.ProductVersion; if ($versionInfo) { Write-Output $versionInfo }"') do (
+        set "framegen_section=FSR 3 FrameGen For Cyberpunk 2077 (DLSS Enabler 2077 Edition) (dlss-enabler.dll) Version: %%a"
+        set "framegen_found=1"
+    )
+)
+
+:: Check for dlss-enabler-bridge-2077.dll
+if exist "%CYBERPUNKDIR%\red4ext\plugins\DLSSEnablerBridge2077\dlss-enabler-bridge-2077.dll" (
+    for /f "delims=" %%a in ('powershell -Command "$versionInfo = (Get-Item '%CYBERPUNKDIR%\red4ext\plugins\DLSSEnablerBridge2077\dlss-enabler-bridge-2077.dll').VersionInfo.ProductVersion; if ($versionInfo) { Write-Output $versionInfo }"') do (
+        if defined framegen_section (
+            set "framegen_section=!framegen_section!\nFrameGen Ghosting `Fix` DLSS Enabler Bridge 2077 (dlss-enabler-bridge-2077.dll) Version: %%a"
+        ) else (
+            set "framegen_section=FrameGen Ghosting `Fix` DLSS Enabler Bridge 2077 (dlss-enabler-bridge-2077.dll) Version: %%a"
+        )
+        set "framegen_found=1"
+    )
+)
+
+:: Add Frame Generation Mods section if any mods were found
+if defined framegen_found (
+    echo. >> "%output_file%"
+    echo Detected Frame Generation Mods: >> "%output_file%"
+    powershell -Command "$text = '%framegen_section%' -replace '\\n',\"`n\"; $text" >> "%output_file%"
+)
+
 :: Parse through all files ending with .log, excluding those with .number.log pattern
 echo. >> "%output_file%" 
 echo ======================================================== >> "%output_file%"


### PR DESCRIPTION
If frame generation mods (DLSS Enabler or FrameGen Ghosting Fix) are detected in the game's folder, they'll be added to a dedicated Frame Generation Mods section in the output, along with their versions. 

The new section will appear below the framework mods section only if any of the mentioned frame generation mods are found.